### PR TITLE
Remove incorrect comment.

### DIFF
--- a/src/libstrace/strace_bpf.c
+++ b/src/libstrace/strace_bpf.c
@@ -121,10 +121,6 @@ attach_callback_to_perf_output(struct bpf_ctx *sbcp,
 		return -1;
 	}
 
-	/*
-	 * XXX It can be reasonable to replace sysconf with sched_getaffinity().
-	 *    It will allow us to ignore non-actual CPUs.
-	 */
 	long cpu_qty = sysconf(_SC_NPROCESSORS_ONLN);
 
 	if (!pr_arr_check_quota(sbcp, (unsigned)cpu_qty)) {


### PR DESCRIPTION
sysconf(_SC_NPROCESSORS_ONLN) and sched_getaffinity are not interchangeable and serve different purposes.